### PR TITLE
Linting/cleanup, pure Python PVR image conversion, embed images in .glb (fix loading in browsers), fix "culling" issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pvr
 *.glb
 *.png
+*.ktx
 *.bin
 *.exe
 *.fbx
@@ -136,3 +137,4 @@ Noesis.exe
 noesiskinect.dll
 ReadMe.txt
 pluginsource.zip
+

--- a/GLB/GLBExporter.py
+++ b/GLB/GLBExporter.py
@@ -45,9 +45,14 @@ class GLBExporter:
     self.samplers.append(sampler)
   
   def addData(self, data):
+    # Calculate the current offset
     offset = len(self.data)
+    # Pad current data to 4-byte boundary
+    padding = (4 - (offset % 4)) % 4
+    self.data += bytes(padding)
+    # Add the new data
     self.data += data
-    return offset
+    return offset + padding
   
   def addBufferView(self, bufferView):
     index = len(self.bufferViews)

--- a/PowerVR/PVRPODLoader.py
+++ b/PowerVR/PVRPODLoader.py
@@ -1,10 +1,10 @@
 import struct
 import array
 
-from PowerVR.EPOD import *
+from PowerVR.EPOD import EPODIdentifiers, EPODDefines
 from PowerVR.PVRModel import PVRModel
 from PowerVR.PVRMesh import PVRMesh, EPVRMesh
-from PowerVR.PVRMaterial import PVRMaterial, EPVRMaterial
+from PowerVR.PVRMaterial import PVRMaterial  # , EPVRMaterial
 # from PowerVR.PVRLight import PVRLight, EPVRLight
 from PowerVR.PVRTexture import PVRTexture
 # from PowerVR.PVRCamera import PVRCamera
@@ -93,7 +93,7 @@ class PVRPODLoader:
 
       elif ident == EPODIdentifiers.eSceneFPS | EPODDefines.startTagMask:
         model.fps = struct.unpack("<i", self.stream.read(4))[0]
-        
+
       elif ident == EPODIdentifiers.eSceneUserData | EPODDefines.startTagMask:
         model.userData = self.stream.read(length)
 
@@ -140,24 +140,24 @@ class PVRPODLoader:
 
       elif ident == EPODIdentifiers.eNodeIndex | EPODDefines.startTagMask:
         node.index = struct.unpack("<i", self.stream.read(4))[0]
-      
+
       elif ident == EPODIdentifiers.eNodeName | EPODDefines.startTagMask:
         node.name = self.ReadString(length)
-      
+
       elif ident == EPODIdentifiers.eNodeMaterialIndex | EPODDefines.startTagMask:
         node.materialIndex = struct.unpack("<i", self.stream.read(4))[0]
-      
+
       elif ident == EPODIdentifiers.eNodeParentIndex | EPODDefines.startTagMask:
         node.parentIndex = struct.unpack("<i", self.stream.read(4))[0]
-      
+
       elif ident == EPODIdentifiers.eNodePosition | EPODDefines.startTagMask: # Deprecated
         pos = array.array('f', self.stream.read(length))
         isOldFormat = True;
-      
+
       elif ident == EPODIdentifiers.eNodeRotation | EPODDefines.startTagMask: # Deprecated
         rotation = array.array('f', self.stream.read(length))
         isOldFormat = True;
-      
+
       elif ident == EPODIdentifiers.eNodeScale | EPODDefines.startTagMask: # Deprecated
         scale = array.array('f', self.stream.read(length))
         isOldFormat = True;
@@ -182,16 +182,16 @@ class PVRPODLoader:
         animation.flags = struct.unpack("<I", self.stream.read(4))[0]
       
       elif ident == EPODIdentifiers.eNodeAnimationPositionIndex | EPODDefines.startTagMask:
-        animation.positionIndices = array.array('L', self.stream.read(length))
+        animation.positionIndices = array.array('I', self.stream.read(length))
       
       elif ident == EPODIdentifiers.eNodeAnimationRotationIndex | EPODDefines.startTagMask:
-        animation.rotationIndices = array.array('L', self.stream.read(length))
+        animation.rotationIndices = array.array('I', self.stream.read(length))
       
       elif ident == EPODIdentifiers.eNodeAnimationScaleIndex | EPODDefines.startTagMask:
-        animation.scaleIndices = array.array('L', self.stream.read(length))
+        animation.scaleIndices = array.array('I', self.stream.read(length))
       
       elif ident == EPODIdentifiers.eNodeAnimationMatrixIndex | EPODDefines.startTagMask:
-        animation.matrixIndices = array.array('L', self.stream.read(length))
+        animation.matrixIndices = array.array('I', self.stream.read(length))
       
       elif ident == EPODIdentifiers.eNodeUserData | EPODDefines.startTagMask:
         node.userData = self.stream.read(length)
@@ -222,7 +222,7 @@ class PVRPODLoader:
         podUVWs = struct.unpack("<i", self.stream.read(4))[0]
 
       elif ident == EPODIdentifiers.eMeshStripLength | EPODDefines.startTagMask:
-        mesh.primitiveData["stripLengths"] = array.array('L', self.stream.read(length))
+        mesh.primitiveData["stripLengths"] = array.array('I', self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshNumStrips | EPODDefines.startTagMask:
         mesh.primitiveData["numStrips"] = struct.unpack("<I", self.stream.read(4))[0]
@@ -231,22 +231,19 @@ class PVRPODLoader:
         mesh.AddData(self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshBoneBatchIndexList | EPODDefines.startTagMask:
-        mesh.boneBatches["batches"] = array.array('L', self.stream.read(length))
+        mesh.boneBatches["batches"] = array.array('I', self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshNumBoneIndicesPerBatch | EPODDefines.startTagMask:
-        mesh.boneBatches["boneCounts"] = array.array('L', self.stream.read(length))
+        mesh.boneBatches["boneCounts"] = array.array('I', self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshBoneOffsetPerBatch | EPODDefines.startTagMask:
-        mesh.boneBatches["offsets"] = array.array('L', self.stream.read(length))
+        mesh.boneBatches["offsets"] = array.array('I', self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshMaxNumBonesPerBatch | EPODDefines.startTagMask:
         mesh.boneBatches["boneMax"] = struct.unpack("<I", self.stream.read(4))[0]
 
-      elif ident == EPODIdentifiers.eMeshMaxNumBonesPerBatch | EPODDefines.startTagMask:
+      elif ident == EPODIdentifiers.eMeshNumBoneBatches | EPODDefines.startTagMask:
         mesh.boneBatches["count"] = struct.unpack("<I", self.stream.read(4))[0]
-
-      elif ident == EPODIdentifiers.eMeshUnpackMatrix | EPODDefines.startTagMask:
-        mesh.unpackMatrix = array.array('f', self.stream.read(length))
 
       elif ident == EPODIdentifiers.eMeshUnpackMatrix | EPODDefines.startTagMask:
         mesh.unpackMatrix = array.array('f', self.stream.read(length))
@@ -417,7 +414,7 @@ class PVRPODLoader:
         if dataType == EPVRMesh.FaceData.e16Bit:
           data = array.array('H', self.stream.read(length))
         elif dataType == EPVRMesh.FaceData.e32Bit:
-          data = array.array('L', self.stream.read(length))
+          data = array.array('I', self.stream.read(length))
       
       else:
         self.stream.seek(length, 1)

--- a/PowerVR/PVRTexture.py
+++ b/PowerVR/PVRTexture.py
@@ -222,8 +222,8 @@ class PVRTexture:
     def setName(self, name: str):
         self.name = path.splitext(name)[0]
 
-    def getPath(self, directory: str = "./", extension: str = ".pvr") -> str:
-        return path.join(directory, self.name + extension)
+    def getPath(self, dir: str = "./", ext: str = ".pvr") -> str:
+        return path.join(dir, self.name + ext)
 
     @classmethod
     def from_file(cls, file_path: str) -> 'PVRTexture':

--- a/PowerVR/PVRTexture.py
+++ b/PowerVR/PVRTexture.py
@@ -1,44 +1,497 @@
 # https://github.com/powervr-graphics/WebGL_SDK/blob/4.0/Tools/PVRTexture.js
 # http://cdn.imgtec.com/sdk-documentation/PVR%20File%20Format.Specification.pdf
+
+# https://github.com/GerbilSoft/rom-properties/blob/master/src/librptexture/fileformat/pvr3_structs.h
+# https://github.com/cocos/cocos-engine/blob/v3.8.6/cocos/asset/assets/image-asset.ts
+# https://github.com/nrabinowitz/loaders.gl/blob/master/modules/basis/src/lib/parsers/parse-compressed-texture.js
+
+import struct
+from enum import IntEnum, IntFlag
+from typing import Optional, List, Tuple
 from os import path
 
-class EPVRTexture:
-  class ChannelTypes:
-    UnsignedByteNorm = 0,
-    SignedByteNorm = 1,
-    UnsignedByte = 2,
-    SignedByte = 3,
-    UnsignedShortNorm = 4,
-    SignedShortNorm = 5,
-    UnsignedShort = 6,
-    SignedShort = 7,
-    UnsignedIntegerNorm = 8,
-    SignedIntegerNorm = 9,
-    UnsignedInteger = 10,
-    SignedInteger = 11,
-    SignedFloat = 12,
-    Float = 12 # the name Float is now deprecated.
+# Define Enums for Channel Types, Pixel Formats, Color Spaces, and Flags.
+
+class ChannelTypes(IntEnum):
+    UnsignedByteNorm = 0
+    SignedByteNorm = 1
+    UnsignedByte = 2
+    SignedByte = 3
+    UnsignedShortNorm = 4
+    SignedShortNorm = 5
+    UnsignedShort = 6
+    SignedShort = 7
+    UnsignedIntegerNorm = 8
+    SignedIntegerNorm = 9
+    UnsignedInteger = 10
+    SignedInteger = 11
+    SignedFloat = 12
+    Float = 12  # Deprecated
     UnsignedFloat = 13
 
+class PixelFormat(IntEnum):
+    # PowerVR3 Pixel Formats
+    PVRTC_2BPP_RGB = 0
+    PVRTC_2BPP_RGBA = 1
+    PVRTC_4BPP_RGB = 2
+    PVRTC_4BPP_RGBA = 3
+    PVRTCII_2BPP = 4
+    PVRTCII_4BPP = 5
+    ETC1 = 6
+    DXT1 = 7
+    DXT2 = 8
+    DXT3 = 9
+    DXT4 = 10
+    DXT5 = 11
+    BC1 = DXT1
+    BC2 = DXT3
+    BC3 = DXT5
+    BC4 = 12
+    BC5 = 13
+    BC6 = 14
+    BC7 = 15
+    UYVY = 16
+    YUY2 = 17
+    BW1bpp = 18
+    R9G9B9E5 = 19
+    RGBG8888 = 20
+    GRGB8888 = 21
+    ETC2_RGB = 22
+    ETC2_RGBA = 23
+    ETC2_RGB_A1 = 24
+    EAC_R11 = 25
+    EAC_RG11 = 26
+    ASTC_4x4 = 27
+    ASTC_5x4 = 28
+    ASTC_5x5 = 29
+    ASTC_6x5 = 30
+    ASTC_6x6 = 31
+    ASTC_8x5 = 32
+    ASTC_8x6 = 33
+    ASTC_8x8 = 34
+    ASTC_10x5 = 35
+    ASTC_10x6 = 36
+    ASTC_10x8 = 37
+    ASTC_10x10 = 38
+    ASTC_12x10 = 39
+    ASTC_12x12 = 40
+    ASTC_3x3x3 = 41
+    ASTC_4x3x3 = 42
+    ASTC_4x4x3 = 43
+    ASTC_4x4x4 = 44
+    ASTC_5x4x4 = 45
+    ASTC_5x5x4 = 46
+    ASTC_5x5x5 = 47
+    ASTC_6x5x5 = 48
+    ASTC_6x6x5 = 49
+    ASTC_6x6x6 = 50
+    MAX = 51
+
+class ColorSpace(IntEnum):
+    RGB = 0      # Linear RGB
+    sRGB = 1     # sRGB
+    MAX = 2
+
+class PowerVR3Flags(IntFlag):
+    COMPRESSED = 1 << 0
+    PREMULTIPLIED = 1 << 1
+
+class MetadataKeys(IntEnum):
+    TEXTURE_ATLAS = 0
+    NORMAL_MAP = 1
+    CUBE_MAP = 2
+    ORIENTATION = 3
+    BORDER = 4
+    PADDING = 5
+
+# Define data structures corresponding to the C structs.
+
+class PowerVR3Header:
+    def __init__(self, data: bytes):
+        if len(data) < 52:
+            raise ValueError("Insufficient data for PowerVR3 Header")
+        (
+            self.version,
+            self.flags,
+            self.pixel_format,
+            self.channel_depth,
+            self.color_space,
+            self.channel_type,
+            self.height,
+            self.width,
+            self.depth,
+            self.num_surfaces,
+            self.num_faces,
+            self.mipmap_count,
+            self.metadata_size
+        ) = struct.unpack("<13I", data[:52])
+
+        # Determine endianness
+        if self.version == 0x03525650:
+            self.endian = '<'  # Little endian
+        elif self.version == 0x50565203:
+            self.endian = '>'  # Big endian
+            # Re-parse with big endian
+            (
+                self.version,
+                self.flags,
+                self.pixel_format,
+                self.channel_depth,
+                self.color_space,
+                self.channel_type,
+                self.height,
+                self.width,
+                self.depth,
+                self.num_surfaces,
+                self.num_faces,
+                self.mipmap_count,
+                self.metadata_size
+            ) = struct.unpack(">13I", data[:52])
+        else:
+            raise ValueError("Unknown PowerVR3 version")
+
+class LegacyPVRHeaderV2:
+    def __init__(self, data: bytes):
+        if len(data) < 48:
+            raise ValueError("Insufficient data for Legacy PVR V2 Header")
+        (
+            self.header_size,
+            self.height,
+            self.width,
+            self.mipmap_count,
+            self.pixel_format_and_flags,
+            self.data_size,
+            self.bit_count,
+            self.red_bit_mask,
+            self.green_bit_mask,
+            self.blue_bit_mask,
+            self.alpha_bit_mask,
+            self.magic,
+            self.num_surfaces
+        ) = struct.unpack("<13I", data[:52])
+
+        if self.magic != 0x21525650:
+            raise ValueError("Invalid magic number for Legacy PVR V2 Header")
+
+class LegacyPVRHeaderV1:
+    def __init__(self, data: bytes):
+        if len(data) < 44:
+            raise ValueError("Insufficient data for Legacy PVR V1 Header")
+        (
+            self.header_size,
+            self.height,
+            self.width,
+            self.mipmap_count,
+            self.pixel_format_and_flags,
+            self.data_size,
+            self.bit_count,
+            self.red_bit_mask,
+            self.green_bit_mask,
+            self.blue_bit_mask,
+            self.alpha_bit_mask
+        ) = struct.unpack("<11I", data[:44])
+
 class PVRTexture:
-  def __init__(self):
-    self.name = ""
-    self.version = 0x03525650
-    self.flags = 0
-    self.pixelFormatH = 0
-    self.pixelFormatL = 0
-    self.colourSpace = 0
-    self.channelType = 0
-    self.height = 1
-    self.width = 1
-    self.depth = 1
-    self.numSurfaces = 1
-    self.numFaces = 1
-    self.MIPMapCount = 1
-    self.metaDataSize = 0
+    PVR3_MAGIC = 0x03525650
+    PVR3_MAGIC_SWAP = 0x50565203
+    LEGACY_PVR_V2_MAGIC = 0x21525650
+    LEGACY_PVR_V1_HEADER_SIZE = 44
+    LEGACY_PVR_V2_HEADER_SIZE = 52
+    PVR3_HEADER_SIZE = 52
 
-  def setName(self, name):
-    self.name = path.splitext(name)[0]
+    def __init__(self):
+        self.name: str = ""
+        self.version: int = self.PVR3_MAGIC
+        self.flags: int = 0
+        self.pixel_format_h: int = 0
+        self.pixel_format_l: int = 0
+        self.color_space: ColorSpace = ColorSpace.RGB
+        self.channel_type: ChannelTypes = ChannelTypes.UnsignedByteNorm
+        self.height: int = 1
+        self.width: int = 1
+        self.depth: int = 1
+        self.num_surfaces: int = 1
+        self.num_faces: int = 1
+        self.mipmap_count: int = 1
+        self.metadata_size: int = 0
+        self.pixel_format: Optional[PixelFormat] = None
+        self.compressed_data: bytes = b""
+        self.metadata: dict = {}
 
-  def getPath(self, dir="./", ext=".pvr"):
-    return path.join(dir, self.name + ext)
+    # NOTE: below are camelcase bc that is what the original did
+    def setName(self, name: str):
+        self.name = path.splitext(name)[0]
+
+    def getPath(self, directory: str = "./", extension: str = ".pvr") -> str:
+        return path.join(directory, self.name + extension)
+
+    @classmethod
+    def from_file(cls, file_path: str) -> 'PVRTexture':
+        instance = cls()
+        instance.setName(file_path)  # set_name(file_path)
+        with open(file_path, 'rb') as f:
+            data = f.read()
+            instance.parse(data)
+        return instance
+
+    def parse(self, data: bytes):
+        if len(data) < 4:
+            raise ValueError("Data too short to determine PVR version")
+
+        magic = struct.unpack("<I", data[:4])[0]
+
+        if magic in [self.PVR3_MAGIC, self.PVR3_MAGIC_SWAP]:
+            self._parse_pvr3(data)
+        elif magic == self.LEGACY_PVR_V2_MAGIC:
+            self._parse_legacy_v2(data)
+        else:
+            # Attempt to parse as Legacy V1
+            self._parse_legacy_v1(data)
+
+    def _parse_pvr3(self, data: bytes):
+        header_data = data[:self.PVR3_HEADER_SIZE]
+        header = PowerVR3Header(header_data)
+        self.version = header.version
+        self.flags = header.flags
+        self.pixel_format = PixelFormat(header.pixel_format) if header.pixel_format in PixelFormat.__members__.values() else None
+        self.color_space = ColorSpace(header.color_space) if header.color_space in ColorSpace.__members__.values() else ColorSpace.RGB
+        self.channel_type = ChannelTypes(header.channel_type) if header.channel_type in ChannelTypes.__members__.values() else ChannelTypes.UnsignedByteNorm
+        self.height = header.height
+        self.width = header.width
+        self.depth = header.depth
+        self.num_surfaces = header.num_surfaces
+        self.num_faces = header.num_faces
+        self.mipmap_count = header.mipmap_count
+        self.metadata_size = header.metadata_size
+
+        # Parse metadata if present
+        metadata = {}
+        if self.metadata_size > 0:
+            metadata_data = data[self.PVR3_HEADER_SIZE:self.PVR3_HEADER_SIZE + self.metadata_size]
+            metadata = self._parse_metadata(metadata_data)
+        self.metadata = metadata
+
+        # Extract compressed data
+        self.compressed_data = data[self.PVR3_HEADER_SIZE + self.metadata_size:]
+
+    def _parse_legacy_v2(self, data: bytes):
+        header_size = self.LEGACY_PVR_V2_HEADER_SIZE
+        if len(data) < header_size:
+            raise ValueError("Data too short for Legacy PVR V2 Header")
+        header = LegacyPVRHeaderV2(data[:header_size])
+        self.version = header.magic  # Not exactly version, but to identify it's V2
+        self.flags = header.pixel_format_and_flags
+        self.pixel_format = self._map_legacy_pixel_format(header.pixel_format_and_flags)
+        self.color_space = ColorSpace.RGB  # Legacy might not have color space
+        self.channel_type = ChannelTypes.UnsignedByteNorm  # Legacy might not have channel type
+        self.height = header.height
+        self.width = header.width
+        self.mipmap_count = header.mipmap_count
+        self.compressed_data = data[header_size:]
+
+    def _parse_legacy_v1(self, data: bytes):
+        header_size = self.LEGACY_PVR_V1_HEADER_SIZE
+        if len(data) < header_size:
+            raise ValueError("Data too short for Legacy PVR V1 Header")
+        header = LegacyPVRHeaderV1(data[:header_size])
+        self.version = 1  # Explicitly set version
+        self.flags = header.pixel_format_and_flags
+        self.pixel_format = self._map_legacy_pixel_format(header.pixel_format_and_flags)
+        self.color_space = ColorSpace.RGB  # Legacy might not have color space
+        self.channel_type = ChannelTypes.UnsignedByteNorm  # Legacy might not have channel type
+        self.height = header.height
+        self.width = header.width
+        self.mipmap_count = header.mipmap_count
+        self.compressed_data = data[header_size:]
+
+    def _map_legacy_pixel_format(self, fmt: int) -> Optional[PixelFormat]:
+        legacy_formats = {
+            0x00: PixelFormat.ARGB4444,
+            0x01: PixelFormat.ARGB1555,
+            0x02: PixelFormat.RGB565,
+            0x03: PixelFormat.RGB555,
+            0x04: PixelFormat.RGB888,
+            0x05: PixelFormat.ARGB8888,
+            0x06: PixelFormat.ARGB8332,
+            0x07: PixelFormat.I8,
+            0x08: PixelFormat.AI88,
+            0x09: PixelFormat.BW1bpp,
+            0x0A: PixelFormat.VY1UY0,
+            0x0B: PixelFormat.Y1VY0U,
+            0x0C: PixelFormat.PVRTC2,
+            0x0D: PixelFormat.PVRTC4,
+            # Add more mappings as needed
+        }
+        return legacy_formats.get(fmt, None)
+
+    def _parse_metadata(self, data: bytes) -> dict:
+        metadata = {}
+        offset = 0
+        while offset + 12 <= len(data):
+            fourcc, key, size = struct.unpack("<III", data[offset:offset + 12])
+            offset += 12
+            if offset + size > len(data):
+                break  # Prevent reading beyond data
+            block_data = data[offset:offset + size]
+            offset += size
+            metadata[key] = block_data
+        return metadata
+
+    def get_texture_parameters(self) -> dict:
+        return {
+            "name": self.name,
+            "version": hex(self.version),
+            "flags": self.flags,
+            "pixel_format": self.pixel_format.name if self.pixel_format else None,
+            "color_space": self.color_space.name,
+            "channel_type": self.channel_type.name,
+            "height": self.height,
+            "width": self.width,
+            "depth": self.depth,
+            "num_surfaces": self.num_surfaces,
+            "num_faces": self.num_faces,
+            "mipmap_count": self.mipmap_count,
+            "metadata_size": self.metadata_size,
+            "metadata": self.metadata
+        }
+
+    def get_compressed_data(self) -> bytes:
+        return self.compressed_data
+
+    def extract_mipmaps(self) -> List[bytes]:
+        """
+        Extract mipmaps from the compressed data.
+        Handles PVRTC alignment and size constraints properly.
+        """
+        mipmaps = []
+        data = self.compressed_data
+        offset = 0
+
+        for level in range(self.mipmap_count):
+            # Calculate dimensions for the current mipmap level
+            level_width = max(1, self.width >> level)
+            level_height = max(1, self.height >> level)
+
+            # Calculate the size of the mipmap level
+            level_size = self._calculate_mipmap_size(level_width, level_height)
+
+            # Extract the mipmap data
+            mipmap_data = data[offset:offset + level_size]
+            mipmaps.append(mipmap_data)
+
+            # Update the offset for the next mipmap
+            offset += level_size
+
+            # Ensure 4-byte alignment for the next level
+            padding = (4 - (level_size % 4)) % 4
+            offset += padding
+
+        return mipmaps
+
+    def _calculate_mipmap_size(self, width: int, height: int) -> int:
+        """
+        Calculate the size of a mipmap level based on the pixel format.
+        Handles PVRTC, ETC, and other formats.
+        """
+        if self.pixel_format is None:
+            return 0
+
+        if self.pixel_format in [
+            PixelFormat.PVRTC_2BPP_RGB,
+            PixelFormat.PVRTC_2BPP_RGBA
+        ]:
+            # PVRTC 2bpp: Ensure width is at least 16 and height at least 8
+            block_width = max(width, 16)
+            block_height = max(height, 8)
+            return (block_width * block_height) // 4
+        elif self.pixel_format in [
+            PixelFormat.PVRTC_4BPP_RGB,
+            PixelFormat.PVRTC_4BPP_RGBA
+        ]:
+            # PVRTC 4bpp: Ensure width and height are at least 8
+            block_width = max(width, 8)
+            block_height = max(height, 8)
+            return (block_width * block_height) // 2
+        elif self.pixel_format in [
+            PixelFormat.ETC1,
+            PixelFormat.ETC2_RGB,
+            PixelFormat.ETC2_RGBA,
+            PixelFormat.ETC2_RGB_A1,
+            PixelFormat.EAC_R11,
+            PixelFormat.EAC_RG11
+        ]:
+            # ETC formats: 4x4 blocks, each block is 8 bytes
+            block_width = 4
+            block_height = 4
+            num_blocks = ((width + block_width - 1) // block_width) * ((height + block_height - 1) // block_height)
+            return num_blocks * 8
+        elif self.pixel_format in [
+            PixelFormat.DXT1,
+            PixelFormat.DXT2,
+            PixelFormat.DXT3,
+            PixelFormat.DXT4,
+            PixelFormat.DXT5,
+            PixelFormat.BC1,
+            PixelFormat.BC2,
+            PixelFormat.BC3
+        ]:
+            # S3TC/DXT formats: 4x4 blocks, block size varies
+            block_width = 4
+            block_height = 4
+            bytes_per_block = 8 if self.pixel_format in [PixelFormat.DXT1, PixelFormat.BC1] else 16
+            num_blocks = ((width + block_width - 1) // block_width) * ((height + block_height - 1) // block_height)
+            return num_blocks * bytes_per_block
+        elif self.pixel_format in [
+            PixelFormat.ASTC_4x4,
+            PixelFormat.ASTC_5x4,
+            PixelFormat.ASTC_5x5,
+            PixelFormat.ASTC_6x5,
+            PixelFormat.ASTC_6x6,
+            PixelFormat.ASTC_8x5,
+            PixelFormat.ASTC_8x6,
+            PixelFormat.ASTC_8x8,
+            PixelFormat.ASTC_10x5,
+            PixelFormat.ASTC_10x6,
+            PixelFormat.ASTC_10x8,
+            PixelFormat.ASTC_10x10,
+            PixelFormat.ASTC_12x10,
+            PixelFormat.ASTC_12x12
+        ]:
+            # ASTC formats: Calculate based on block dimensions
+            block_width, block_height = self._get_astc_block_dimensions(self.pixel_format)
+            num_blocks = ((width + block_width - 1) // block_width) * ((height + block_height - 1) // block_height)
+            return num_blocks * 16  # ASTC uses 16 bytes per block
+        else:
+            # Unsupported format
+            raise ValueError(f"Unsupported pixel format: {self.pixel_format}")
+
+    def _get_astc_block_dimensions(self, fmt: PixelFormat) -> Tuple[int, int]:
+        """
+        Return the block dimensions for ASTC formats.
+        """
+        astc_block_map = {
+            PixelFormat.ASTC_4x4: (4, 4),
+            PixelFormat.ASTC_5x4: (5, 4),
+            PixelFormat.ASTC_5x5: (5, 5),
+            PixelFormat.ASTC_6x5: (6, 5),
+            PixelFormat.ASTC_6x6: (6, 6),
+            PixelFormat.ASTC_8x5: (8, 5),
+            PixelFormat.ASTC_8x6: (8, 6),
+            PixelFormat.ASTC_8x8: (8, 8),
+            PixelFormat.ASTC_10x5: (10, 5),
+            PixelFormat.ASTC_10x6: (10, 6),
+            PixelFormat.ASTC_10x8: (10, 8),
+            PixelFormat.ASTC_10x10: (10, 10),
+            PixelFormat.ASTC_12x10: (12, 10),
+            PixelFormat.ASTC_12x12: (12, 12),
+        }
+        return astc_block_map.get(fmt, (4, 4))  # Default to 4x4 if unknown
+
+    def __repr__(self):
+        return f"PVRTexture(name={self.name}, width={self.width}, height={self.height}, mipmap_count={self.mipmap_count}, pixel_format={self.pixel_format})"
+
+# Example Usage:
+# texture = PVRTexture.from_file("example.pvr")
+# params = texture.get_texture_parameters()
+# mipmaps = texture.extract_mipmaps()
+# print(params)

--- a/PowerVR/pvr2image.py
+++ b/PowerVR/pvr2image.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+import os
+import argparse
+from PVRTexture import PVRTexture, PixelFormat
+import texture2ddecoder
+from PIL import Image
+
+def convert_bgra_to_rgba(data: bytes, width: int, height: int) -> bytes:
+    """
+    Convert BGRA raw data to RGBA format.
+    """
+    rgba_data = bytearray(len(data))
+    for i in range(0, len(data), 4):
+        # Swap BGRA to RGBA
+        rgba_data[i] = data[i + 2]  # R <- B
+        rgba_data[i + 1] = data[i + 1]  # G <- G
+        rgba_data[i + 2] = data[i]  # B <- R
+        rgba_data[i + 3] = data[i + 3]  # A <- A
+    return bytes(rgba_data)
+
+def pvrtexture_to_image(texture):  # input = PVRTexture type
+    # Check if the pixel format is supported for decoding
+    if texture.pixel_format not in [
+        PixelFormat.PVRTC_2BPP_RGB,
+        PixelFormat.PVRTC_2BPP_RGBA,
+        PixelFormat.PVRTC_4BPP_RGB,
+        PixelFormat.PVRTC_4BPP_RGBA,
+        PixelFormat.ETC1
+    ]:
+        raise NotImplementedError(f"Unsupported pixel format: {texture.pixel_format}")
+
+    # Extract the highest resolution mipmap
+    mipmaps = texture.extract_mipmaps()
+    if not mipmaps:
+        raise Exception("No mipmaps found in the PVR file.")
+
+    # Decode the highest resolution mipmap
+    compressed_data = mipmaps[0]  # Use the largest mipmap (index 0)
+    width, height = texture.width, texture.height
+
+    if texture.pixel_format in [PixelFormat.PVRTC_2BPP_RGB, PixelFormat.PVRTC_2BPP_RGBA]:
+        decoded_data = texture2ddecoder.decode_pvrtc(compressed_data, width, height, True)
+    elif texture.pixel_format in [PixelFormat.PVRTC_4BPP_RGB, PixelFormat.PVRTC_4BPP_RGBA]:
+        decoded_data = texture2ddecoder.decode_pvrtc(compressed_data, width, height, False)
+    elif texture.pixel_format == PixelFormat.ETC1:
+        decoded_data = texture2ddecoder.decode_etc1(compressed_data, width, height)
+    else:
+        raise NotImplementedError(f"Decoding for pixel format {texture.pixel_format} is not implemented.")
+
+    # Convert BGRA to RGBA (texture2ddecoder emits BGRA)
+    rgba_data = convert_bgra_to_rgba(decoded_data, width, height)
+
+    # Convert the raw RGBA data to a PIL image
+    image = Image.frombytes('RGBA', (width, height), rgba_data)
+    return image
+
+if __name__ == '__main__':
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description="Convert PVR textures to PNG format.")
+    parser.add_argument('-i', '--input', required=True, help="Path to the input PVR file.")
+    parser.add_argument('-d', '--output_dir', required=True, help="Directory to save the output PNG.")
+    args = parser.parse_args()
+
+    # Load the PVR texture
+    texture = PVRTexture.from_file(args.input)
+
+    image = pvrtexture_to_image(texture)  # Convert to PIL image
+
+    # Create the output directory if it doesn't exist
+    #os.makedirs(args.output_dir, exist_ok=True)
+    # Construct the output PNG file path
+    #base_name = os.path.splitext(os.path.basename(args.input))[0]
+    output_file = args.output_dir  # os.path.join(args.output_dir, f"{base_name}.png")
+
+    image.save(output_file)
+    print(f"Converted {args.input} to {output_file} successfully.")

--- a/PowerVR/pvr2ktx.py
+++ b/PowerVR/pvr2ktx.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+import sys
+import struct
+from PVRTexture import PVRTexture, PixelFormat
+
+def map_pvr_format_to_gl(pvr_format):
+    # Map PVR pixel format to OpenGL internal format constants
+    pvr_to_gl_format = {
+        PixelFormat.PVRTC_2BPP_RGB: 0x8C01,     # GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG
+        PixelFormat.PVRTC_2BPP_RGBA: 0x8C03,    # GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG
+        PixelFormat.PVRTC_4BPP_RGB: 0x8C00,     # GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG
+        PixelFormat.PVRTC_4BPP_RGBA: 0x8C02,    # GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG
+        PixelFormat.ETC1: 0x8D64,               # GL_ETC1_RGB8_OES
+        PixelFormat.ETC2_RGB: 0x9274,           # GL_COMPRESSED_RGB8_ETC2
+        PixelFormat.ETC2_RGBA: 0x9278,          # GL_COMPRESSED_RGBA8_ETC2_EAC
+        # Add more mappings as needed
+    }
+    return pvr_to_gl_format.get(pvr_format, None)
+
+def map_gl_base_format(gl_internal_format):
+    # Map GL internal format to base format
+    gl_base_format_map = {
+        0x8C01: 0x1907,  # GL_RGB
+        0x8C03: 0x1908,  # GL_RGBA
+        0x8C00: 0x1907,  # GL_RGB
+        0x8C02: 0x1908,  # GL_RGBA
+        0x8D64: 0x1907,  # GL_RGB
+        0x9274: 0x1907,  # GL_RGB
+        0x9278: 0x1908,  # GL_RGBA
+        # Add more mappings as needed
+    }
+    return gl_base_format_map.get(gl_internal_format, None)
+
+def pvr_to_ktx(pvr_file_path, ktx_file):
+    # Load the PVR texture
+    texture = PVRTexture.from_file(pvr_file_path)
+
+    # Extract mipmaps
+    mipmaps = texture.extract_mipmaps()
+
+    # Prepare the KTX header
+    ktx_header = bytearray()
+    ktx_header.extend(b'\xABKTX 11\xBB\r\n\x1A\n')  # identifier
+    ktx_header.extend(struct.pack('<I', 0x04030201))  # endianness
+    ktx_header.extend(struct.pack('<I', 0))  # glType (0 for compressed data)
+    ktx_header.extend(struct.pack('<I', 1))  # glTypeSize
+    ktx_header.extend(struct.pack('<I', 0))  # glFormat
+    glInternalFormat = map_pvr_format_to_gl(texture.pixel_format)
+    if glInternalFormat is None:
+        raise NotImplementedError(f"Unsupported PVR pixel format: {texture.pixel_format}")
+
+    ktx_header.extend(struct.pack('<I', glInternalFormat))  # glInternalFormat
+    glBaseInternalFormat = map_gl_base_format(glInternalFormat)
+    if glBaseInternalFormat is None:
+        raise NotImplementedError(f"Unsupported GL internal format: {hex(glInternalFormat)}")
+
+    ktx_header.extend(struct.pack('<I', glBaseInternalFormat))  # glBaseInternalFormat
+    ktx_header.extend(struct.pack('<I', texture.width))  # pixelWidth
+    ktx_header.extend(struct.pack('<I', texture.height))  # pixelHeight
+    ktx_header.extend(struct.pack('<I', 0))  # pixelDepth
+    ktx_header.extend(struct.pack('<I', 0))  # numberOfArrayElements
+    ktx_header.extend(struct.pack('<I', texture.num_faces))  # numberOfFaces
+    ktx_header.extend(struct.pack('<I', texture.mipmap_count))  # numberOfMipmapLevels
+    ktx_header.extend(struct.pack('<I', 0))  # bytesOfKeyValueData
+
+    # Write to KTX file handle
+    ktx_file.write(ktx_header)
+    for mipmap_data in mipmaps:
+        image_size = len(mipmap_data)
+        # Write imageSize field
+        ktx_file.write(struct.pack('<I', image_size))
+        # Write image data
+        ktx_file.write(mipmap_data)
+        # 4-byte alignment padding
+        padding = (3 - ((image_size + 3) % 4))
+        if padding != 0:
+            ktx_file.write(b'\x00' * padding)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: python pvr2ktx.py input.pvr output.ktx")
+        sys.exit(1)
+
+    pvr_file = sys.argv[1]
+    ktx_file = sys.argv[2]
+    with open(ktx_file, 'wb') as f:
+        pvr_to_ktx(pvr_file, f)
+    print(f"Converted {pvr_file} to {ktx_file} successfully.")

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Optionally, you can install Noesis to automagically convert the GLB to FBX! [You
 
 ### Usage
 
-`extract.py` can be used to convert `.pod` models to the `.glb` model format:
+`pod2glb.py` can be used to convert `.pod` models to the `.glb` model format:
 
 ```bash
-python3 extract.py <.pod model path> <.glb output path> <-f>
+python3 pod2glb.py <.pod model path> <.glb output path> <-f>
 ```
 
-Textures are assumed to be in the same directory as extract.py
+Textures are assumed to be in the same directory as pod2glb.py
 
 ### Installation Steps
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # PVR Model Extractor (POD2GLB)
 
-Crappy Python decompiler (made even crappier, but hey, it works) for the [PowerVR model]() format (`.pod`), built for ripping models from Nintendo's mobile games (particularly Miitomo). It includes utils to convert `.pod` models to the binary glTF (`.glb`) format.
+Crappy Python converter for the [PowerVR model](https://github.com/powervr-graphics/Native_SDK/blob/R15.1-v3.5/Tools/PVRTModelPOD.h) format (`.pod`), built for ripping models from Nintendo's mobile games (particularly Miitomo). It includes utils to convert `.pod` models to the binary glTF (`.glb`) format.
 
 This tool works, but please make an issue in case for other models that break this extractor! This extractor was intended for Miitomo - if there was a better way I could have implemented some fixes let me know!
 
 ### Requirements
 
 * Python 3.12 or above (Tested with Python 3.12)
-* PVRTexTool from the [Imgination Technology Website](https://developer.imaginationtech.com/solutions/pvrtextool/)
-`PVR_TEX_TOOL_PATH` to suit your setup.
-* A glTF plugin for your 3D tool of choice, such as [this glTF plugin for Blender](https://docs.blender.org/manual/en/latest/addons/import_export/scene_gltf2.html). This will let you load .gltf models. 
+* PVRTexTool from the [Imgination Technologies Website](https://developer.imaginationtech.com/solutions/pvrtextool/). Specify `--pvrtextool-path` if the script's arguments doesn't automatically find it.
+* _Alternatively..._ Instead of PVRTexTool, you can now use the pvr2image.py script in the repo. You will need to install `texture2ddecoder` from PyPI, then specify it like so: `--pvrtextool-path PowerVR/pvr2image.py` and it should work. Please contact me or [Arian](https://github.com/ariankordi) for any issues with this.
+* A glTF plugin for your 3D tool of choice, such as [this glTF plugin for Blender](https://docs.blender.org/manual/en/latest/addons/import_export/scene_gltf2.html). This will let you load .gltf models. The models may also load in [generic glTF web viewers](https://gltf-viewer.donmccurdy.com).
 
 Optionally, you can install Noesis to automagically convert the GLB to FBX! [You can download Noesis here!](https://www.richwhitehouse.com/index.php?content=inc_projects.php&showproject=91)
 

--- a/pod2glb.py
+++ b/pod2glb.py
@@ -9,9 +9,9 @@ import subprocess as sp
 import platform
 import PIL
 
-# File paths for advanced people
-NOESIS = ""
-PVRTEXTOOL = ""
+# Override paths for tools.
+NOESIS_PATH = ""
+PVR_TEX_TOOL_PATH = ""
 
 # Global Variables
 FIX_COMPLETED = False  # Don't touch
@@ -35,14 +35,22 @@ print(f"""
 
 """)
 print(f"[DEBUG] Platform is {platform}")
+
+# Utility function to get the path of a program.
+def get_platform_path(tool_name):
+    path_mapping = {
+        "Windows": f"{os.path.abspath(os.getcwd())}\\{tool_name}.exe",
+    }
+    # Use Linux mapping as the default (for macOS too):
+    return path_mapping.get(platform, f"{os.path.abspath(os.getcwd())}/{tool_name}")
+
 class POD2GLB:
 
     def __init__(self):
         self.glb = None
         self.pod = None
         self.scene = None
-        self.fix_uvs = True
-
+        #self.fix_uvs = True
 
     @classmethod
     def open(cls, inpath):
@@ -80,126 +88,40 @@ class POD2GLB:
         return samplers
 
     def convert_textures(self):
+        # Resolve strings to GLenum values.
+        GLENUM = {
+            "GL_NEAREST": 9728,
+            "GL_LINEAR": 9729,
+            "GL_NEAREST_MIPMAP_NEAREST": 9784,
+            "GL_LINEAR_MIPMAP_NEAREST": 9785,
+            "GL_NEAREST_MIPMAP_LINEAR": 9786,
+            "GL_LINEAR_MIPMAP_LINEAR": 9787,
+            "GL_CLAMP_TO_EDGE": 33061,
+            "GL_MIRRORED_REPEAT": 33648,
+            "GL_REPEAT": 10497
+        }
+
         alphahotfix = False
         alphaarray = []
         diffusearray = []
         print("[Part 04] Converting textures...")
         if platform == "Windows":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "\\PVRTexToolCLI.exe")
+            pvrtextool_path = ((os.path.abspath(os.getcwd())) + "\\PVRTexToolCLI.exe")
         elif platform == "Darwin":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
+            pvrtextool_path = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
         elif platform == "Linux":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
+            pvrtextool_path = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
         else:
             print("UNKNOWN PLATFORM! DEFAULTING TO LINUX...")
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
+            pvrtextool_path = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
         # Override if user has a file path for PVRTexTool
-        if PVRTEXTOOL != "":
-            print(f"[OVERRIDE] Overriding path for PVRTexTool with {PVRTEXTOOL}")
-            pathforcheck = PVRTEXTOOL
-        print("[DEBUG] Path for PVRTexToolCLI should be in: " + pathforcheck)
-        SANITYCHECK = path.exists(pathforcheck)
-        if not xmlsupport:
-            for (textureIndex, texture) in enumerate(self.scene.textures):
-                print(f"[Part 04-1] Adding image {texture.getPath()}...")
-                self.glb.addImage({
-                    "uri": texture.getPath(dir="", ext=".png")
-                })
-                self.glb.addSampler({
-                    "magFilter": 9729,
-                    "minFilter": 9987,
-                    "wrapS": 10497,
-                    "wrapT": 10497
-                })
-                self.glb.addTexture({
-                    "name": texture.name,
-                    "sampler": textureIndex,
-                    "source": textureIndex
-                })
-        else:
-            # Enchanced XML sampler import support
-            xmlmaterials = xmlroot.find("Materials")
-            xmlmaterial = xmlmaterials.findall('Material')
-            textureIndex = 0
-            for material in xmlmaterial:
-                for sampler in material.findall('Sampler2D'):
-                    magFilter = 9729
-                    minFilter = 9987
-                    wrapS = 10497
-                    wrapT = 10497
-                    texture = {
-                        "path": str((sampler.find("FileName")).text).replace(".tga", ".png"),
-                        "name": str(sampler.attrib['Name'])
-                    }
-                    mag = sampler.find("GL_TEXTURE_MAG_FILTER")
-                    min = sampler.find("GL_TEXTURE_MIN_FILTER")
-                    S = sampler.find("GL_TEXTURE_WRAP_S")
-                    T = sampler.find("GL_TEXTURE_WRAP_T")
+        if PVR_TEX_TOOL_PATH != "":
+            print(f"[OVERRIDE] Overriding path for PVRTexTool with {PVR_TEX_TOOL_PATH}")
+            pvrtextool_path = PVR_TEX_TOOL_PATH
+        print("[DEBUG] Path for PVRTexToolCLI should be in: " + pvrtextool_path)
+        pvrtextool_exists = path.exists(pvrtextool_path)
 
-                    # If statement hell for deciding which stuff is which.
-
-                    # Magnification filter
-                    if mag.text == "GL_NEAREST":
-                        magFilter = 9728
-                    elif mag.text == "GL_LINEAR":
-                        magFilter = 9729
-
-                    # Minification filter
-                    if min.text == "GL_NEAREST":
-                        minFilter = 9728
-                    elif min.text == "GL_LINEAR":
-                        minFilter = 9729
-                    elif min.text == "GL_NEAREST_MIPMAP_NEAREST":
-                        minFilter = 9784
-                    elif min.text == "GL_LINEAR_MIPMAP_NEAREST":
-                        minFilter = 9785
-                    elif min.text == "GL_NEAREST_MIPMAP_LINEAR":
-                        minFilter = 9786
-                    elif min.text == "GL_LINEAR_MIPMAP_LINEAR":
-                        minFilter = 9787
-
-                    # S (U) Wrapping Mode
-                    if S.text == "GL_CLAMP_TO_EDGE":
-                        wrapS = 33061
-                    elif S.text == "GL_MIRRORED_REPEAT":
-                        wrapS = 33648
-                    elif S.text == "GL_REPEAT":
-                        wrapS = 10947
-
-                    # T (V) Wrapping Mode
-                    if T.text == "GL_CLAMP_TO_EDGE":
-                        wrapT = 33061
-                    elif T.text == "GL_MIRRORED_REPEAT":
-                        wrapT = 33648
-                    elif T.text == "GL_REPEAT":
-                        wrapT = 10947
-
-                    print(f"[Part 04-1] Adding image {texture['name']}, path {texture['path']}...")
-                    self.glb.addImage({
-                        "uri": texture['path']
-                    })
-                    self.glb.addSampler({
-                        "magFilter": magFilter,
-                        "minFilter": minFilter,
-                        "wrapS": wrapS,
-                        "wrapT": wrapT
-                    })
-                    self.glb.addTexture({
-                        "name": texture["name"],
-                        "sampler": textureIndex,
-                        "source": textureIndex
-                    })
-                    textureIndex = textureIndex + 1
-                    if texture["name"] == "uAlbedoTexture":
-                        diffusearray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
-                        print("[DEBUG] Diffuse Map found.")
-                    elif texture["name"] == "uAlphaTexture":
-                        alphaarray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
-                        alphahotfix = True
-                        print("[DEBUG] Alpha Map found.")
-
-
-        if SANITYCHECK:  # Is PVRTexTool available?
+        if pvrtextool_exists:  # Is PVRTexTool available?
             print("[Part 04-2] Now converting all images!")
 
             for root, dirs, files in os.walk(os.path.dirname(pathto)):
@@ -209,7 +131,7 @@ class POD2GLB:
                         print(f"[Part 04-2] Converting {pvr} to png...")
                         print(f"[DEBUG] Will be saved at {output}")
                         sp.call([
-                            pathforcheck,
+                            pvrtextool_path,
                             "-d", output,
                             "-i", os.path.join(root, pvr)
                         ])
@@ -238,6 +160,73 @@ class POD2GLB:
 
         else:
             print("[Part 04-2 - WARNING!] Textures will be added, but not converted. You don't have PVRTexToolCLI downloaded or didn't put it in the same directory as the converter (Or you misspelled string inside the PVRTEXTOOL variable if you tried to override the paths!). To download it, go to https://developer.imaginationtech.com/solutions/pvrtextool/. If you have downloaded, move PVRTexToolCLI in the same directory as this script! The usual path (for Windows) is C:\\Imagination Technologies\\PowerVR_Graphics\\PowerVR_Tools\\PVRTexTool\\CLI\\Windows_x86_64.")
+
+
+        if not xmlsupport:
+            for (textureIndex, texture) in enumerate(self.scene.textures):
+                print(f"[Part 04-1] Adding image {texture.getPath()}...")
+
+                self.glb.addImage({
+                    "uri": texture.getPath(dir="", ext=".png")
+                })
+                self.glb.addSampler({
+                    "magFilter": GLENUM["GL_LINEAR"],
+                    "minFilter": GLENUM["GL_LINEAR"],
+                    "wrapS": GLENUM["GL_REPEAT"],
+                    "wrapT": GLENUM["GL_REPEAT"]
+                })
+                self.glb.addTexture({
+                    "name": texture.name,
+                    "sampler": textureIndex,
+                    "source": textureIndex
+                })
+        else:
+            # Enchanced XML sampler import support
+            xmlmaterials = xmlroot.find("Materials")
+            xmlmaterial = xmlmaterials.findall('Material')
+            textureIndex = 0
+            for material in xmlmaterial:
+                for sampler in material.findall('Sampler2D'):
+
+                    texture = {
+                        "path": str((sampler.find("FileName")).text).replace(".tga", ".png"),
+                        "name": str(sampler.attrib['Name'])
+                    }
+                    mag = sampler.find("GL_TEXTURE_MAG_FILTER")
+                    min = sampler.find("GL_TEXTURE_MIN_FILTER")
+                    S = sampler.find("GL_TEXTURE_WRAP_S")
+                    T = sampler.find("GL_TEXTURE_WRAP_T")
+
+                    magFilter = GLENUM.get(mag.text, GLENUM["GL_LINEAR"])  # Magnificiation filter
+                    minFilter = GLENUM.get(min.text, GLENUM["GL_LINEAR"])  # Minification filter
+                    wrapS = GLENUM.get(S.text, GLENUM["GL_REPEAT"])  # S (U) Wrapping Mode
+                    wrapT = GLENUM.get(T.text, GLENUM["GL_REPEAT"])  # T (V) Wrapping Mode
+
+                    print(f"[Part 04-1] Adding image {texture['name']}, path {texture['path']}...")
+
+                    self.glb.addImage({
+                        "uri": texture['path']
+                    })
+
+                    self.glb.addSampler({
+                        "magFilter": magFilter,
+                        "minFilter": minFilter,
+                        "wrapS": wrapS,
+                        "wrapT": wrapT
+                    })
+                    self.glb.addTexture({
+                        "name": texture["name"],
+                        "sampler": textureIndex,
+                        "source": textureIndex
+                    })
+                    textureIndex = textureIndex + 1
+                    if texture["name"] == "uAlbedoTexture":
+                        diffusearray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
+                        print("[DEBUG] Diffuse Map found.")
+                    elif texture["name"] == "uAlphaTexture":
+                        alphaarray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
+                        alphahotfix = True
+                        print("[DEBUG] Alpha Map found.")
 
     def convert_materials(self):
         print("[Part 05] Converting materials...")
@@ -325,7 +314,7 @@ class POD2GLB:
                                 #Alpha["index"] = int(textureIndex)
                                 #if sampler.find("UVIdx") is not None:
                                 #    Alpha["texCoord"] = int((sampler.find("UVIdx")).text)
-                                textureIndex += 1
+                                #textureIndex += 1
                                 print("[DEBUG] Has alpha support!")
 
                         print(f"[Part 05-1] Adding material {material.name}...")
@@ -406,18 +395,17 @@ class POD2GLB:
                     "buffer": 0,
                     "byteOffset": self.glb.addData(indices.tobytes()),
                     "byteLength": len(indices) * indices.itemsize,
-                    "target": 34963
+                    "target": 34963     # ELEMENT_ARRAY_BUFFER
                 }),
                 "byteOffset": 0,
                 # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
-                "componentType": 5123,
+                "componentType": 5123,  # UNSIGNED_SHORT
                 "count": numFaces * 3,
                 "type": "SCALAR"
             })
 
             # vertex buffer view
             vertexElements = mesh.vertexElements
-
 
             vertexBufferView = self.glb.addBufferView({
                 "buffer": 0,
@@ -428,23 +416,25 @@ class POD2GLB:
 
             for name in vertexElements:
                 element = vertexElements[name]
-                componentType = 5126
-                type = "VEC3"
+                componentType = 5126  # FLOAT
+                name_to_type = {
+                    "TEXCOORD_0": "VEC2",
+                    "COLOR_0": "VEC4",
+                    # position, normal, tangent: vec3
+                    # NOTE: color is R8G8B8A8_UNORM and wont work(???)
+                }
+                type = name_to_type.get(name, "VEC3")  # vec3 default
 
-                if name == "TEXCOORD_0":
-                    type = "VEC2"
-
-                elif name == "COLOR_0":  # not implemented
-                    continue
-
-                accessorIndex = self.glb.addAccessor({
+                accessor_data = {
                     "bufferView": vertexBufferView,
                     "byteOffset": element["offset"],
                     # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
                     "componentType": componentType,
                     "count": numVertices,
                     "type": type
-                })
+                }
+
+                accessorIndex = self.glb.addAccessor(accessor_data)
                 attributes[name] = accessorIndex
 
             # POD meshes only have one primitive?
@@ -458,36 +448,20 @@ class POD2GLB:
                 }],
             })
 
-def NoesisStuff(file, pathforcheck):
+def run_noesis_conversion(file, noesis_path):
     print("Using Noesis to convert to FBX as a way to fix it mainly because I'm lazy")
     if platform == "Windows":
         print("[FIX 01] Platform is Windows/MS-DOS, running Noesis natively")
         sp.call([
-            pathforcheck,
-            "?cmode",
-            file,
-            os.path.basename(os.path.splitext(file)[0] + ".fbx")
-        ])
-    elif platform == "Darwin":
-        print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Note: This is for macOS - No idea if wine would be in PATH)")
-        sp.call([
-            "wine " + pathforcheck,
-            "?cmode",
-            file,
-            os.path.basename(os.path.splitext(file)[0] + ".fbx")
-        ])
-    elif platform == "Linux":
-        print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Linux)")
-        sp.call([
-            "wine " + pathforcheck,
+            noesis_path,
             "?cmode",
             file,
             os.path.basename(os.path.splitext(file)[0] + ".fbx")
         ])
     else:
-        print("[FIX 01] Platform is unknown, trying to use Wine to run Noesis")
+        print("[FIX 01] Trying to use Wine to run Noesis")
         sp.call([
-            "wine " + pathforcheck,
+            "wine " + noesis_path,
             "?cmode",
             file,
             os.path.basename(os.path.splitext(file)[0] + ".fbx")
@@ -495,47 +469,39 @@ def NoesisStuff(file, pathforcheck):
     print("[FIX - FINISH!] Should generate a FBX file - use that instead of the GLB file.")
     global FIX_COMPLETED
     FIX_COMPLETED = True
-def NoesisFix(file):
+
+def convert_to_fbx(file):
     print("[FIX 00] Trying to convert the GLB to FBX because Blender doesn't understand the armature this tool generates.")
     # Check if 64-bit version is available
     if platform == "Windows":
-        pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis64.exe")
-    elif platform == "Darwin":
-        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
-    elif platform == "Linux":
-        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
+        noesis_path = ((os.path.abspath(os.getcwd())) + "\\Noesis64.exe")
     else:
-        print("[FIX 00 - WARNING] UNKNOWN PLATFORM! DEFAULTING TO UNIX...")
-        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
+        noesis_path = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
 
-    print("[DEBUG] Path for Noesis should be in: " + pathforcheck)
-    SANITYCHECK = path.exists(pathforcheck)
-    if SANITYCHECK:
-        NoesisStuff(file, pathforcheck)
+    print("[DEBUG] Path for Noesis should be in: " + noesis_path)
+    noesis_exists = path.exists(noesis_path)
+    if noesis_exists:
+        run_noesis_conversion(file, noesis_path)
     else:
         print("[DEBUG] 64-bit version NOT detected.")
     if FIX_COMPLETED:
         # Check if 32-bit version is available
         if platform == "Windows":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis.exe")
-        elif platform == "Darwin":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
-        elif platform == "Linux":
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+            noesis_path = ((os.path.abspath(os.getcwd())) + "\\Noesis.exe")
         else:
-            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+            noesis_path = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
 
         # Override if user has a file path for Noesis
 
-            if NOESIS != "":
-                print(f"[OVERRIDE] Overriding path for Noesis with {NOESIS}")
-                pathforcheck = NOESIS
-        print("[DEBUG] Path for Noesis should be in: " + pathforcheck)
-        if SANITYCHECK:
-            NoesisStuff(file, pathforcheck)
+            if NOESIS_PATH != "":
+                print(f"[OVERRIDE] Overriding path for Noesis with {NOESIS_PATH}")
+                noesis_path = NOESIS_PATH
+        print("[DEBUG] Path for Noesis should be in: " + noesis_path)
+        if noesis_exists:
+            run_noesis_conversion(file, noesis_path)
         else:
             if not FIX_COMPLETED:
-                print("[FIX - ERROR!] Fix will NOT continue. You don't have Noesis downloaded or didn't put it in the same directory as the converter (Or you misspelled the NOESIS variable if you tried to override the paths!). To download it, go to https://www.richwhitehouse.com/index.php?content=inc_projects.php&showproject=91.")
+                print("[FIX - ERROR!] Fix will NOT continue. You don't have Noesis downloaded or didn't put it in the same directory as the converter (Or you misspelled the NOESIS_PATH variable if you tried to override the paths!). To download it, go to https://www.richwhitehouse.com/index.php?content=inc_projects.php&showproject=91.")
 
 def help():
     print("""
@@ -547,8 +513,8 @@ Options:
 
 Advanced:
 (Both variables have to be set inside the Python script. If you need to reset, just clear everything in the string.)
-PVRTEXTOOL: Variable used to override the location of PVRTexToolCli.
-NOESIS: Variable used to override the location of Noesis.
+PVR_TEX_TOOL_PATH: Variable used to override the location of PVRTexToolCli.
+NOESIS_PATH: Variable used to override the location of Noesis.
 """)
 #try:
 pathto = argv[1]
@@ -581,6 +547,6 @@ except NameError:
     print("[ERROR!] GLB not specified.")
 try:
     if argv[3] == "--fix-armature" or "-f":
-        NoesisFix(argv[2])
+        convert_to_fbx(argv[2])
 except IndexError:
     print("[DEBUG] Will not convert to FBX via Noesis as -f or --fix-armature option was not specified.")

--- a/pod2glb.py
+++ b/pod2glb.py
@@ -199,7 +199,7 @@ class POD2GLB:
                         print("[DEBUG] Alpha Map found.")
 
 
-        if SANITYCHECK:
+        if SANITYCHECK:  # Is PVRTexTool available?
             print("[Part 04-2] Now converting all images!")
 
             for root, dirs, files in os.walk(os.path.dirname(pathto)):
@@ -214,7 +214,10 @@ class POD2GLB:
                             "-i", os.path.join(root, pvr)
                         ])
                         print("[HOTFIX] PVRTexTool for some reason generates a _Out file, so automatically deleting that.")
-                        os.remove(os.path.join(root, os.path.splitext(pvr)[0] + "_Out.pvr"))
+                        try:
+                            os.remove(os.path.join(root, os.path.splitext(pvr)[0] + "_Out.pvr"))
+                        except FileNotFoundError:  # Ignore if that _Out file doesn't exist.
+                            pass
             if alphahotfix:
                 print("[HOTFIX] Due to contraints with GLTF files, alpha maps will be inserted into the diffuse map.")
                 for diffusemap in diffusearray:

--- a/pod2glb.py
+++ b/pod2glb.py
@@ -313,37 +313,31 @@ class POD2GLB:
             return self.convert_materials_with_xml()
         # Standard non-XML path.
         for (materialIndex, material) in enumerate(self.scene.materials):
+            materialGLB = {
+                "name": material.name,
+            }
             if material.diffuseTextureIndex > -1:
-                pbr = {
+                materialGLB["pbrMetallicRoughness"] = {
                     "baseColorTexture": {
                         "index": material.diffuseTextureIndex,
                     },
                     "roughnessFactor": 1 - material.shininess,
                 }
             else:
-                pbr = {
+                materialGLB["pbrMetallicRoughness"] = {
                     "baseColorFactor": material.diffuse.tolist() + [1],
                     "roughnessFactor": 1 - material.shininess,
                 }
             if material.bumpMapTextureIndex > -1:
-                normal = {
+                materialGLB["normalTexture"] = {
                     "index": material.bumpMapTextureIndex
                 }
-            else:
-                normal = {}
             if material.opacityTextureIndex > -1:
-                Alpha = {
+                materialGLB["occlusionTexture"] = {
                     "index": material.bumpMapTextureIndex
                 }
-            else:
-                Alpha = {}
 
-            self.glb.addMaterial({
-                "name": material.name,
-                "pbrMetallicRoughness": pbr,
-                "normalTexture": normal,
-                "occlusionTexture": Alpha
-            })
+            self.glb.addMaterial(materialGLB)
 
     def convert_materials_with_xml(self):
         xmlmaterials = xmlroot.find("Materials")

--- a/pod2glb.py
+++ b/pod2glb.py
@@ -43,506 +43,506 @@ print(f"""
 print(f"[DEBUG] Platform is {platform}")
 class POD2GLB:
 
-  def __init__(self):
-    self.glb = None
-    self.pod = None
-    self.scene = None
-    self.fix_uvs = True
-    
-
-  @classmethod
-  def open(cls, inpath):
-    print("[Part 00] Loading POD...")
-    converter = cls()
-    converter.load(inpath)
-    return converter
-
-  def load(self, inpath):
-    print("[Part 01] Starting up all loaders...") 
-    # create a glb exporter
-    self.glb = GLBExporter()
-    # create a pvr pod parser
-    self.pod = PVRPODLoader.open(inpath)
-    self.scene = self.pod.scene
-    self.convert_meshes()
-    self.convert_nodes()
-    self.convert_textures()
-    self.convert_materials()
-
-  def save(self, path):
-    print("[Part 06] Saving all data to a GLB format...")
-    if xmlsupport == True:
-      print('[WARNING] Due to constraints with GLTF, any Mask textures found will be attached as "Emission". It is up to you to reattach and correctly apply this map.')
-    self.glb.save(path)
-    print("[FINISH!] Done!")
-
-  def findallsamplers(xmlmaterial):
-      samplers = 0
-      for material in xmlmaterial:
-        samp = material.findall("Sampler2D")
-        for sample in samp:
-          samplers = samplers + 1
-      print(f"[DEBUG] Found {samplers} in XML file.")
-      return(samplers)
-
-  def convert_textures(self):  
-    alphahotfix = False
-    alphaarray = []
-    diffusearray = []
-    print("[Part 04] Converting textures...")
-    if platform == "Windows":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "\\PVRTexToolCLI.exe")
-    elif platform == "Darwin":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
-    elif platform == "Linux":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
-    else:
-      print("UNKNOWN PLATFORM! DEFAULTING TO LINUX...")
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
-    # Override if user has a file path for PVRTexTool
-    if PVRTEXTOOL != "":
-      print(f"[OVERRIDE] Overriding path for PVRTexTool with {PVRTEXTOOL}")
-      pathforcheck = PVRTEXTOOL
-    print("[DEBUG] Path for PVRTexToolCLI should be in: " + pathforcheck)
-    SANITYCHECK = path.exists(pathforcheck)
-    if xmlsupport == False:
-      for (textureIndex, texture) in enumerate(self.scene.textures):
-        print(f"[Part 04-1] Adding image {texture.getPath()}...")
-        self.glb.addImage({
-          "uri": texture.getPath(dir="", ext=".png")
-        })
-        self.glb.addSampler({
-          "magFilter": 9729,
-          "minFilter": 9987,
-          "wrapS": 10497,
-          "wrapT": 10497
-        })
-        self.glb.addTexture({
-          "name": texture.name,
-          "sampler": textureIndex,
-          "source": textureIndex
-        })
-    else:
-      # Enchanced XML sampler import support
-      xmlmaterials = xmlroot.find("Materials")
-      xmlmaterial = xmlmaterials.findall('Material')
-      textureIndex = 0
-      for material in xmlmaterial:
-        for sampler in material.findall('Sampler2D'):
-          magFilter = 9729
-          minFilter = 9987
-          wrapS = 10497
-          wrapT = 10497
-          texture = {
-            "path": str((sampler.find("FileName")).text).replace(".tga",".png"),
-            "name": str(sampler.attrib['Name'])
-          }
-          mag = sampler.find("GL_TEXTURE_MAG_FILTER")
-          min = sampler.find("GL_TEXTURE_MIN_FILTER")
-          S = sampler.find("GL_TEXTURE_WRAP_S")
-          T = sampler.find("GL_TEXTURE_WRAP_T")
-
-          # If statement hell for deciding which stuff is which.
-
-          # Magnification filter
-          if mag.text == "GL_NEAREST":
-            magFilter = 9728
-          elif mag.text == "GL_LINEAR":
-            magFilter = 9729
-
-          # Minification filter
-          if min.text == "GL_NEAREST":
-            minFilter = 9728
-          elif min.text == "GL_LINEAR":
-            minFilter = 9729
-          elif min.text == "GL_NEAREST_MIPMAP_NEAREST":
-            minFilter = 9784
-          elif min.text == "GL_LINEAR_MIPMAP_NEAREST":
-            minFilter = 9785
-          elif min.text == "GL_NEAREST_MIPMAP_LINEAR":
-            minFilter = 9786
-          elif min.text == "GL_LINEAR_MIPMAP_LINEAR":
-            minFilter = 9787
-
-          # S (U) Wrapping Mode
-          if S.text == "GL_CLAMP_TO_EDGE":
-            wrapS = 33061
-          elif S.text == "GL_MIRRORED_REPEAT":
-            wrapS = 33648
-          elif S.text == "GL_REPEAT":
-            wrapS = 10947
-
-          # T (V) Wrapping Mode
-          if T.text == "GL_CLAMP_TO_EDGE":
-            wrapT = 33061
-          elif T.text == "GL_MIRRORED_REPEAT":
-            wrapT = 33648
-          elif T.text == "GL_REPEAT":
-            wrapT = 10947
-
-          print(f"[Part 04-1] Adding image {texture['name']}, path {texture['path']}...")
-          self.glb.addImage({
-            "uri": texture['path']
-          })
-          self.glb.addSampler({
-            "magFilter": magFilter,
-            "minFilter": minFilter,
-            "wrapS": wrapS,
-            "wrapT": wrapT
-          })
-          self.glb.addTexture({
-            "name": texture["name"],
-            "sampler": textureIndex,
-            "source": textureIndex
-          })
-          textureIndex = textureIndex + 1
-          if texture["name"] == "uAlbedoTexture":
-            diffusearray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
-            print("[DEBUG] Diffuse Map found.")
-          elif texture["name"] == "uAlphaTexture":
-            alphaarray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
-            alphahotfix = True
-            print("[DEBUG] Alpha Map found.")
+    def __init__(self):
+        self.glb = None
+        self.pod = None
+        self.scene = None
+        self.fix_uvs = True
 
 
-    if SANITYCHECK == True:
-      print("[Part 04-2] Now converting all images!")
-      tobeconvert = []
-      for root, dirs, files in os.walk(os.path.dirname(pathto)):
-        for pvr in files:
-          if str(pvr).endswith(".pvr"):
-            output = os.path.join(os.path.dirname(pathout), os.path.basename(os.path.splitext(pvr)[0]+".png"))
-            print(f"[Part 04-2] Converting {pvr} to png...")
-            print(f"[DEBUG] Will be saved at {output}")
-            sp.call([
-              pathforcheck,
-              "-d", output,
-              "-i", os.path.join(root, pvr)
-            ])
-            print("[HOTFIX] PVRTexTool for some reason generates a _Out file, so automatically deleting that.")
-            os.remove(os.path.join(root, os.path.splitext(pvr)[0]+"_Out.pvr"))
-      if alphahotfix == True:
-        print("[HOTFIX] Due to contraints with GLTF files, alpha maps will be inserted into the diffuse map.")
-        for diffusemap in diffusearray:
-          for comalpha in range(len(diffusearray)):
-            diffusepath = diffusemap
-            try:
-              alphamap = PIL.Image.open(alphaarray[comalpha]).convert("L")
-              diffusemap = PIL.Image.open(diffusemap).convert("RGB")
+    @classmethod
+    def open(cls, inpath):
+        print("[Part 00] Loading POD...")
+        converter = cls()
+        converter.load(inpath)
+        return converter
 
-              dw, dh = diffusemap.size
-              alpharesize = (dw, dh)
-              alphamap.resize(alpharesize)
-              diffusemap.putalpha(alphamap)
-              diffusemap.save(diffusepath)
-            except FileNotFoundError:
-              print("[DEBUG] Not applying non-exsistent alpha.")
+    def load(self, inpath):
+        print("[Part 01] Starting up all loaders...")
+        # create a glb exporter
+        self.glb = GLBExporter()
+        # create a pvr pod parser
+        self.pod = PVRPODLoader.open(inpath)
+        self.scene = self.pod.scene
+        self.convert_meshes()
+        self.convert_nodes()
+        self.convert_textures()
+        self.convert_materials()
 
+    def save(self, path):
+        print("[Part 06] Saving all data to a GLB format...")
+        if xmlsupport == True:
+            print('[WARNING] Due to constraints with GLTF, any Mask textures found will be attached as "Emission". It is up to you to reattach and correctly apply this map.')
+        self.glb.save(path)
+        print("[FINISH!] Done!")
 
-    else:
-        print("[Part 04-2 - WARNING!] Textures will be added, but not converted. You don't have PVRTexToolCLI downloaded or didn't put it in the same directory as the converter (Or you misspelled string inside the PVRTEXTOOL variable if you tried to override the paths!). To download it, go to https://developer.imaginationtech.com/solutions/pvrtextool/. If you have downloaded, move PVRTexToolCLI in the same directory as this script! The usual path (for Windows) is C:\\Imagination Technologies\\PowerVR_Graphics\\PowerVR_Tools\\PVRTexTool\\CLI\\Windows_x86_64.")
-  
-  def convert_materials(self):
-    print("[Part 05] Converting materials...")
-    if xmlsupport == False:
-      for (materialIndex, material) in enumerate(self.scene.materials):
-        if material.diffuseTextureIndex > -1:
-          pbr = {
-            "baseColorTexture": {
-              "index": material.diffuseTextureIndex,
-            },
-            "roughnessFactor": 1 - material.shininess,
-          }
-        else: 
-          pbr = {
-            "baseColorFactor": material.diffuse.tolist() + [1],
-            "roughnessFactor": 1 - material.shininess,
-          }
-        if material.bumpMapTextureIndex > -1:
-          normal = {
-            "index": material.bumpMapTextureIndex
-          }
+    def findallsamplers(xmlmaterial):
+        samplers = 0
+        for material in xmlmaterial:
+            samp = material.findall("Sampler2D")
+            for sample in samp:
+                samplers = samplers + 1
+        print(f"[DEBUG] Found {samplers} in XML file.")
+        return(samplers)
+
+    def convert_textures(self):
+        alphahotfix = False
+        alphaarray = []
+        diffusearray = []
+        print("[Part 04] Converting textures...")
+        if platform == "Windows":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "\\PVRTexToolCLI.exe")
+        elif platform == "Darwin":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
+        elif platform == "Linux":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
         else:
-          normal = {}
-        if material.opacityTextureIndex > -1:
-          Alpha = {
-            "index": material.bumpMapTextureIndex
-          }
+            print("UNKNOWN PLATFORM! DEFAULTING TO LINUX...")
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/PVRTexToolCLI")
+        # Override if user has a file path for PVRTexTool
+        if PVRTEXTOOL != "":
+            print(f"[OVERRIDE] Overriding path for PVRTexTool with {PVRTEXTOOL}")
+            pathforcheck = PVRTEXTOOL
+        print("[DEBUG] Path for PVRTexToolCLI should be in: " + pathforcheck)
+        SANITYCHECK = path.exists(pathforcheck)
+        if xmlsupport == False:
+            for (textureIndex, texture) in enumerate(self.scene.textures):
+                print(f"[Part 04-1] Adding image {texture.getPath()}...")
+                self.glb.addImage({
+                    "uri": texture.getPath(dir="", ext=".png")
+                })
+                self.glb.addSampler({
+                    "magFilter": 9729,
+                    "minFilter": 9987,
+                    "wrapS": 10497,
+                    "wrapT": 10497
+                })
+                self.glb.addTexture({
+                    "name": texture.name,
+                    "sampler": textureIndex,
+                    "source": textureIndex
+                })
         else:
-          Alpha = {}
+            # Enchanced XML sampler import support
+            xmlmaterials = xmlroot.find("Materials")
+            xmlmaterial = xmlmaterials.findall('Material')
+            textureIndex = 0
+            for material in xmlmaterial:
+                for sampler in material.findall('Sampler2D'):
+                    magFilter = 9729
+                    minFilter = 9987
+                    wrapS = 10497
+                    wrapT = 10497
+                    texture = {
+                        "path": str((sampler.find("FileName")).text).replace(".tga",".png"),
+                        "name": str(sampler.attrib['Name'])
+                    }
+                    mag = sampler.find("GL_TEXTURE_MAG_FILTER")
+                    min = sampler.find("GL_TEXTURE_MIN_FILTER")
+                    S = sampler.find("GL_TEXTURE_WRAP_S")
+                    T = sampler.find("GL_TEXTURE_WRAP_T")
 
-        self.glb.addMaterial({
-          "name": material.name,
-          "pbrMetallicRoughness": pbr,
-          "normalTexture": normal,
-          "occlusionTexture": Alpha
-        })
-    else:
-      xmlmaterials = xmlroot.find("Materials")
-      xmlmaterial = xmlmaterials.findall('Material')
-      textureIndex = 0
-      for (materialIndex, material) in enumerate(self.scene.materials):
-        # Settings to list which option is available
-        hasAlpha = False
-        # Makes texture visible
-        Albedo = {
-          "baseColorTexture": {},
-          "roughnessFactor": 1 - material.shininess
-        }
-        Normal = {}
-        Mask = {}
-        Alpha = {}
-        for xmmaterial in xmlmaterial:
-          print(f"[DEBUG] Material from POD Name is {material.name}")
-          print(f"[DEBUG] Material from XML is called {xmmaterial.attrib['Name']}")
-          if str(material.name) == xmmaterial.attrib['Name']:
-            for sampler in xmmaterial.findall('Sampler2D'):
-              if sampler.attrib['Name'] == 'uAlbedoTexture':
-                Albedo["baseColorTexture"] = {"index": int(textureIndex)}
-                if sampler.find("UVIdx") is not None:
-                  Albedo["texCoord"] = int((sampler.find("UVIdx")).text)
-                textureIndex = textureIndex + 1
-                print("[DEBUG] Has albedo texture!")
+                    # If statement hell for deciding which stuff is which.
 
-              elif sampler.attrib['Name'] == 'uNormalTexture':
-                hasNormal = True
-                Normal["index"] = int(textureIndex)
-                if sampler.find("UVIdx") is not None:
-                  Normal["texCoord"] = int((sampler.find("UVIdx")).text)
-                textureIndex += 1
-                print("[DEBUG] Has normal texture!")
+                    # Magnification filter
+                    if mag.text == "GL_NEAREST":
+                        magFilter = 9728
+                    elif mag.text == "GL_LINEAR":
+                        magFilter = 9729
 
-              elif sampler.attrib['Name'] == 'uMaskTexture':
-                hasMask = True
-                Mask["index"] = int(textureIndex)
-                if sampler.find("UVIdx") is not None:
-                  Mask["texCoord"] = int((sampler.find("UVIdx")).text)
-                textureIndex += 1
-                print("[DEBUG] Has mask texture!")
+                    # Minification filter
+                    if min.text == "GL_NEAREST":
+                        minFilter = 9728
+                    elif min.text == "GL_LINEAR":
+                        minFilter = 9729
+                    elif min.text == "GL_NEAREST_MIPMAP_NEAREST":
+                        minFilter = 9784
+                    elif min.text == "GL_LINEAR_MIPMAP_NEAREST":
+                        minFilter = 9785
+                    elif min.text == "GL_NEAREST_MIPMAP_LINEAR":
+                        minFilter = 9786
+                    elif min.text == "GL_LINEAR_MIPMAP_LINEAR":
+                        minFilter = 9787
 
-              elif sampler.attrib['Name'] == 'uAlphaTexture':
-                hasAlpha =True
+                    # S (U) Wrapping Mode
+                    if S.text == "GL_CLAMP_TO_EDGE":
+                        wrapS = 33061
+                    elif S.text == "GL_MIRRORED_REPEAT":
+                        wrapS = 33648
+                    elif S.text == "GL_REPEAT":
+                        wrapS = 10947
 
-                # Old alpha code.
+                    # T (V) Wrapping Mode
+                    if T.text == "GL_CLAMP_TO_EDGE":
+                        wrapT = 33061
+                    elif T.text == "GL_MIRRORED_REPEAT":
+                        wrapT = 33648
+                    elif T.text == "GL_REPEAT":
+                        wrapT = 10947
 
-                #Alpha["index"] = int(textureIndex)
-                #if sampler.find("UVIdx") is not None:
-                #  Alpha["texCoord"] = int((sampler.find("UVIdx")).text)
-                textureIndex += 1
-                print("[DEBUG] Has alpha support!")
-    
-            print(f"[Part 05-1] Adding material {material.name}...")
+                    print(f"[Part 04-1] Adding image {texture['name']}, path {texture['path']}...")
+                    self.glb.addImage({
+                        "uri": texture['path']
+                    })
+                    self.glb.addSampler({
+                        "magFilter": magFilter,
+                        "minFilter": minFilter,
+                        "wrapS": wrapS,
+                        "wrapT": wrapT
+                    })
+                    self.glb.addTexture({
+                        "name": texture["name"],
+                        "sampler": textureIndex,
+                        "source": textureIndex
+                    })
+                    textureIndex = textureIndex + 1
+                    if texture["name"] == "uAlbedoTexture":
+                        diffusearray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
+                        print("[DEBUG] Diffuse Map found.")
+                    elif texture["name"] == "uAlphaTexture":
+                        alphaarray.append(os.path.join(os.path.dirname(pathout), os.path.basename(texture['path'])))
+                        alphahotfix = True
+                        print("[DEBUG] Alpha Map found.")
 
-            PODMaterial = {
-              "name": material.name,
-              "pbrMetallicRoughness": Albedo,
-              "normalTexture": Normal,
-              "emissiveTexture": Mask,
-              "doubleSided": True,
+
+        if SANITYCHECK == True:
+            print("[Part 04-2] Now converting all images!")
+            tobeconvert = []
+            for root, dirs, files in os.walk(os.path.dirname(pathto)):
+                for pvr in files:
+                    if str(pvr).endswith(".pvr"):
+                        output = os.path.join(os.path.dirname(pathout), os.path.basename(os.path.splitext(pvr)[0]+".png"))
+                        print(f"[Part 04-2] Converting {pvr} to png...")
+                        print(f"[DEBUG] Will be saved at {output}")
+                        sp.call([
+                            pathforcheck,
+                            "-d", output,
+                            "-i", os.path.join(root, pvr)
+                        ])
+                        print("[HOTFIX] PVRTexTool for some reason generates a _Out file, so automatically deleting that.")
+                        os.remove(os.path.join(root, os.path.splitext(pvr)[0]+"_Out.pvr"))
+            if alphahotfix == True:
+                print("[HOTFIX] Due to contraints with GLTF files, alpha maps will be inserted into the diffuse map.")
+                for diffusemap in diffusearray:
+                    for comalpha in range(len(diffusearray)):
+                        diffusepath = diffusemap
+                        try:
+                            alphamap = PIL.Image.open(alphaarray[comalpha]).convert("L")
+                            diffusemap = PIL.Image.open(diffusemap).convert("RGB")
+
+                            dw, dh = diffusemap.size
+                            alpharesize = (dw, dh)
+                            alphamap.resize(alpharesize)
+                            diffusemap.putalpha(alphamap)
+                            diffusemap.save(diffusepath)
+                        except FileNotFoundError:
+                            print("[DEBUG] Not applying non-exsistent alpha.")
+
+
+        else:
+            print("[Part 04-2 - WARNING!] Textures will be added, but not converted. You don't have PVRTexToolCLI downloaded or didn't put it in the same directory as the converter (Or you misspelled string inside the PVRTEXTOOL variable if you tried to override the paths!). To download it, go to https://developer.imaginationtech.com/solutions/pvrtextool/. If you have downloaded, move PVRTexToolCLI in the same directory as this script! The usual path (for Windows) is C:\\Imagination Technologies\\PowerVR_Graphics\\PowerVR_Tools\\PVRTexTool\\CLI\\Windows_x86_64.")
+
+    def convert_materials(self):
+        print("[Part 05] Converting materials...")
+        if xmlsupport == False:
+            for (materialIndex, material) in enumerate(self.scene.materials):
+                if material.diffuseTextureIndex > -1:
+                    pbr = {
+                        "baseColorTexture": {
+                            "index": material.diffuseTextureIndex,
+                        },
+                        "roughnessFactor": 1 - material.shininess,
+                    }
+                else:
+                    pbr = {
+                        "baseColorFactor": material.diffuse.tolist() + [1],
+                        "roughnessFactor": 1 - material.shininess,
+                    }
+                if material.bumpMapTextureIndex > -1:
+                    normal = {
+                        "index": material.bumpMapTextureIndex
+                    }
+                else:
+                    normal = {}
+                if material.opacityTextureIndex > -1:
+                    Alpha = {
+                        "index": material.bumpMapTextureIndex
+                    }
+                else:
+                    Alpha = {}
+
+                self.glb.addMaterial({
+                    "name": material.name,
+                    "pbrMetallicRoughness": pbr,
+                    "normalTexture": normal,
+                    "occlusionTexture": Alpha
+                })
+        else:
+            xmlmaterials = xmlroot.find("Materials")
+            xmlmaterial = xmlmaterials.findall('Material')
+            textureIndex = 0
+            for (materialIndex, material) in enumerate(self.scene.materials):
+                # Settings to list which option is available
+                hasAlpha = False
+                # Makes texture visible
+                Albedo = {
+                    "baseColorTexture": {},
+                    "roughnessFactor": 1 - material.shininess
+                }
+                Normal = {}
+                Mask = {}
+                Alpha = {}
+                for xmmaterial in xmlmaterial:
+                    print(f"[DEBUG] Material from POD Name is {material.name}")
+                    print(f"[DEBUG] Material from XML is called {xmmaterial.attrib['Name']}")
+                    if str(material.name) == xmmaterial.attrib['Name']:
+                        for sampler in xmmaterial.findall('Sampler2D'):
+                            if sampler.attrib['Name'] == 'uAlbedoTexture':
+                                Albedo["baseColorTexture"] = {"index": int(textureIndex)}
+                                if sampler.find("UVIdx") is not None:
+                                    Albedo["texCoord"] = int((sampler.find("UVIdx")).text)
+                                textureIndex = textureIndex + 1
+                                print("[DEBUG] Has albedo texture!")
+
+                            elif sampler.attrib['Name'] == 'uNormalTexture':
+                                hasNormal = True
+                                Normal["index"] = int(textureIndex)
+                                if sampler.find("UVIdx") is not None:
+                                    Normal["texCoord"] = int((sampler.find("UVIdx")).text)
+                                textureIndex += 1
+                                print("[DEBUG] Has normal texture!")
+
+                            elif sampler.attrib['Name'] == 'uMaskTexture':
+                                hasMask = True
+                                Mask["index"] = int(textureIndex)
+                                if sampler.find("UVIdx") is not None:
+                                    Mask["texCoord"] = int((sampler.find("UVIdx")).text)
+                                textureIndex += 1
+                                print("[DEBUG] Has mask texture!")
+
+                            elif sampler.attrib['Name'] == 'uAlphaTexture':
+                                hasAlpha =True
+
+                                # Old alpha code.
+
+                                #Alpha["index"] = int(textureIndex)
+                                #if sampler.find("UVIdx") is not None:
+                                #    Alpha["texCoord"] = int((sampler.find("UVIdx")).text)
+                                textureIndex += 1
+                                print("[DEBUG] Has alpha support!")
+
+                        print(f"[Part 05-1] Adding material {material.name}...")
+
+                        PODMaterial = {
+                            "name": material.name,
+                            "pbrMetallicRoughness": Albedo,
+                            "normalTexture": Normal,
+                            "emissiveTexture": Mask,
+                            "doubleSided": True,
+                        }
+
+                        if hasAlpha == True:
+                            # Old code.
+                            #PODMaterial["occlusionTexture"] = Alpha
+                            PODMaterial["alphaMode"] = "BLEND"
+
+                        if xmmaterial.find("Culling") is not None:
+                            if xmmaterial.find("Culling").text == 'None':
+                                print(f"[DEBUG] Material {material.name} does NOT have backface culling on.")
+                            else:
+                                PODMaterial["doubleSided"] == False
+                                print(f"[DEBUG] Material {material.name} has backface culling on.")
+
+                        self.glb.addMaterial(PODMaterial)
+                    else:
+                        print(f"[DEBUG] Material is not the same! {xmmaterial.attrib['Name']} is not the same as {material.name}")
+
+    def convert_nodes(self):
+        print("[Part 03] Converting nodes...")
+        for (nodeIndex, node) in enumerate(self.scene.nodes):
+
+            nodeEntry = {
+                "name": node.name,
+                "children": [i for (i, node) in enumerate(self.scene.nodes) if node.parentIndex == nodeIndex],
+                "translation": node.animation.positions.tolist(),
+                "scale": node.animation.scales[0:3].tolist(),
+                "rotation": node.animation.rotations[0:4].tolist(),
             }
-            
-            if hasAlpha == True:
-              # Old code.
-              #PODMaterial["occlusionTexture"] = Alpha
-              PODMaterial["alphaMode"] = "BLEND"
-            
-            if xmmaterial.find("Culling") is not None:
-              if xmmaterial.find("Culling").text == 'None':
-                print(f"[DEBUG] Material {material.name} does NOT have backface culling on.")
-              else:
-                PODMaterial["doubleSided"] == False
-                print(f"[DEBUG] Material {material.name} has backface culling on.")
 
-            self.glb.addMaterial(PODMaterial)
-          else:
-            print(f"[DEBUG] Material is not the same! {xmmaterial.attrib['Name']} is not the same as {material.name}")
 
-  def convert_nodes(self):
-    print("[Part 03] Converting nodes...")
-    for (nodeIndex, node) in enumerate(self.scene.nodes):
+            # if the node has a mesh index
+            if node.index != -1:
+                print(f"[Part 03-1] {node.name} has a mesh index.")
+                meshIndex = node.index
+                nodeEntry["mesh"] = meshIndex
+                if node.materialIndex != -1:
+                    self.glb.meshes[meshIndex]["primitives"][0]["material"] = node.materialIndex
 
-      nodeEntry = {
-        "name": node.name,
-        "children": [i for (i, node) in enumerate(self.scene.nodes) if node.parentIndex == nodeIndex],
-        "translation": node.animation.positions.tolist(),
-        "scale": node.animation.scales[0:3].tolist(),
-        "rotation": node.animation.rotations[0:4].tolist(),
-      }
-    
-      
-      # if the node has a mesh index
-      if node.index != -1:
-        print(f"[Part 03-1] {node.name} has a mesh index.")
-        meshIndex = node.index
-        nodeEntry["mesh"] = meshIndex
-        if node.materialIndex != -1:
-          self.glb.meshes[meshIndex]["primitives"][0]["material"] = node.materialIndex
+            # if the node index is -1 it is a root node
+            if node.parentIndex == -1:
+                print(f"[Part 03-1] {node.name} is a root node.")
+                self.glb.addRootNodeIndex(nodeIndex)
+            print(f"[Part 03-2] Now adding {node.name}.")
+            self.glb.addNode(nodeEntry)
+            # To convert or not to convert
+            if node.animation.matrices != None:
+                print(f"Converting matrix animation data for: {node.name}")
+                print("Currently animation porting is not available at this time, sorry :(")
+                # keyframes = []
+                # matrix = node.animation.matrices.tolist()
+                # for x in range(len(matrix)):
+                #     if x != 15 or:
+                #        rotationX = PVRMaths.PVRMatrix4x4RX3D()
 
-      # if the node index is -1 it is a root node
-      if node.parentIndex == -1:
-        print(f"[Part 03-1] {node.name} is a root node.")
-        self.glb.addRootNodeIndex(nodeIndex)
-      print(f"[Part 03-2] Now adding {node.name}.")
-      self.glb.addNode(nodeEntry)
-      # To convert or not to convert
-      if node.animation.matrices != None:
-        print(f"Converting matrix animation data for: {node.name}")
-        print("Currently animation porting is not available at this time, sorry :(")
-        # keyframes = []
-        # matrix = node.animation.matrices.tolist()
-        # for x in range(len(matrix)):
-        #   if x != 15 or:
-        #    rotationX = PVRMaths.PVRMatrix4x4RX3D()
 
-  
-  def convert_meshes(self):
-    print("[Part 02] Converting meshes...")
-    for (meshIndex, mesh) in enumerate(self.scene.meshes):
-      attributes = {}
-      numFaces = mesh.primitiveData["numFaces"]
-      numVertices = mesh.primitiveData["numVertices"]
+    def convert_meshes(self):
+        print("[Part 02] Converting meshes...")
+        for (meshIndex, mesh) in enumerate(self.scene.meshes):
+            attributes = {}
+            numFaces = mesh.primitiveData["numFaces"]
+            numVertices = mesh.primitiveData["numVertices"]
 
-      # face index buffer view
-      indices = mesh.faces["data"]
-      indicesAccessorIndex = self.glb.addAccessor({
-        "bufferView": self.glb.addBufferView({
-          "buffer": 0,
-          "byteOffset": self.glb.addData(indices.tobytes()),
-          "byteLength": len(indices) * indices.itemsize,
-          "target": 34963
-        }),
-        "byteOffset": 0,
-        # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
-        "componentType": 5123,
-        "count": numFaces * 3,
-        "type": "SCALAR"
-      })
+            # face index buffer view
+            indices = mesh.faces["data"]
+            indicesAccessorIndex = self.glb.addAccessor({
+                "bufferView": self.glb.addBufferView({
+                    "buffer": 0,
+                    "byteOffset": self.glb.addData(indices.tobytes()),
+                    "byteLength": len(indices) * indices.itemsize,
+                    "target": 34963
+                }),
+                "byteOffset": 0,
+                # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
+                "componentType": 5123,
+                "count": numFaces * 3,
+                "type": "SCALAR"
+            })
 
-      # vertex buffer view
-      vertexElements = mesh.vertexElements
+            # vertex buffer view
+            vertexElements = mesh.vertexElements
 
 
 
 
-      vertexBufferView = self.glb.addBufferView({
-        "buffer": 0,
-        "byteOffset": self.glb.addData(mesh.vertexElementData[0]),
-        "byteStride": vertexElements["POSITION"]["stride"],
-        "byteLength": len(mesh.vertexElementData[0]),
-      })
+            vertexBufferView = self.glb.addBufferView({
+                "buffer": 0,
+                "byteOffset": self.glb.addData(mesh.vertexElementData[0]),
+                "byteStride": vertexElements["POSITION"]["stride"],
+                "byteLength": len(mesh.vertexElementData[0]),
+            })
 
-      for name in vertexElements:
-        element = vertexElements[name]
-        componentType = 5126
-        type = "VEC3"
-        
-        if name == "TEXCOORD_0":
-          type = "VEC2"
-        
-        elif name == "COLOR_0": # not implemented
-          continue
+            for name in vertexElements:
+                element = vertexElements[name]
+                componentType = 5126
+                type = "VEC3"
 
-        accessorIndex = self.glb.addAccessor({
-          "bufferView": vertexBufferView,
-          "byteOffset": element["offset"],
-          # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
-          "componentType": componentType,
-          "count": numVertices,
-          "type": type
-        })
-        attributes[name] = accessorIndex
+                if name == "TEXCOORD_0":
+                    type = "VEC2"
 
-      # POD meshes only have one primitive?
-      # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#primitive
-      print("[Part 02-1] Adding mesh...")
-      self.glb.addMesh({
-        "primitives": [{
-          "attributes": attributes,
-          "indices": indicesAccessorIndex,
-          "mode": 4,
-        }],
-      })
+                elif name == "COLOR_0": # not implemented
+                    continue
+
+                accessorIndex = self.glb.addAccessor({
+                    "bufferView": vertexBufferView,
+                    "byteOffset": element["offset"],
+                    # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#accessor-element-size
+                    "componentType": componentType,
+                    "count": numVertices,
+                    "type": type
+                })
+                attributes[name] = accessorIndex
+
+            # POD meshes only have one primitive?
+            # https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#primitive
+            print("[Part 02-1] Adding mesh...")
+            self.glb.addMesh({
+                "primitives": [{
+                    "attributes": attributes,
+                    "indices": indicesAccessorIndex,
+                    "mode": 4,
+                }],
+            })
 
 def NoesisStuff(file, pathforcheck):
-  print("Using Noesis to convert to FBX as a way to fix it mainly because I'm lazy")
-  if platform == "Windows":
-    print("[FIX 01] Platform is Windows/MS-DOS, running Noesis natively")
-    sp.call([
-      pathforcheck,
-      "?cmode",
-      file,
-      os.path.basename(os.path.splitext(file)[0]+".fbx")
-    ])
-  elif platform == "Darwin":
-    print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Note: This is for macOS - No idea if wine would be in PATH)")
-    sp.call([
-      "wine " + pathforcheck,
-      "?cmode",
-      file,
-      os.path.basename(os.path.splitext(file)[0]+".fbx")
-    ])
-  elif platform == "Linux":
-    print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Linux)")
-    sp.call([
-      "wine " + pathforcheck,
-      "?cmode",
-      file,
-      os.path.basename(os.path.splitext(file)[0]+".fbx")
-    ])
-  else:
-    print("[FIX 01] Platform is unknown, trying to use Wine to run Noesis")
-    sp.call([
-      "wine " + pathforcheck,
-      "?cmode",
-      file,
-      os.path.basename(os.path.splitext(file)[0]+".fbx")
-    ])
-  print("[FIX - FINISH!] Should generate a FBX file - use that instead of the GLB file.")
-  FIX_COMPLETED = True
-def NoesisFix(file):
-  print("[FIX 00] Trying to convert the GLB to FBX because Blender doesn't understand the armature this tool generates.")
-  # Check if 64-bit version is available
-  if platform == "Windows":
-    pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis64.exe")
-  elif platform == "Darwin":
-    pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
-  elif platform == "Linux":
-    pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
-  else:
-    print("[FIX 00 - WARNING] UNKNOWN PLATFORM! DEFAULTING TO UNIX...")
-    pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
-
-  print("[DEBUG] Path for Noesis should be in: " + pathforcheck)
-  SANITYCHECK = path.exists(pathforcheck)
-  if SANITYCHECK == True:
-    NoesisStuff(file, pathforcheck)
-  else:
-    print("[DEBUG] 64-bit version NOT detected.")
-  if FIX_COMPLETED == True:
-    # Check if 32-bit version is available
+    print("Using Noesis to convert to FBX as a way to fix it mainly because I'm lazy")
     if platform == "Windows":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis.exe")
+        print("[FIX 01] Platform is Windows/MS-DOS, running Noesis natively")
+        sp.call([
+            pathforcheck,
+            "?cmode",
+            file,
+            os.path.basename(os.path.splitext(file)[0]+".fbx")
+        ])
     elif platform == "Darwin":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+        print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Note: This is for macOS - No idea if wine would be in PATH)")
+        sp.call([
+            "wine " + pathforcheck,
+            "?cmode",
+            file,
+            os.path.basename(os.path.splitext(file)[0]+".fbx")
+        ])
     elif platform == "Linux":
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+        print("[FIX 01] Platform is UNIX-based, trying to use Wine to run Noesis (Linux)")
+        sp.call([
+            "wine " + pathforcheck,
+            "?cmode",
+            file,
+            os.path.basename(os.path.splitext(file)[0]+".fbx")
+        ])
     else:
-      pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
-    
-    # Override if user has a file path for Noesis
+        print("[FIX 01] Platform is unknown, trying to use Wine to run Noesis")
+        sp.call([
+            "wine " + pathforcheck,
+            "?cmode",
+            file,
+            os.path.basename(os.path.splitext(file)[0]+".fbx")
+        ])
+    print("[FIX - FINISH!] Should generate a FBX file - use that instead of the GLB file.")
+    FIX_COMPLETED = True
+def NoesisFix(file):
+    print("[FIX 00] Trying to convert the GLB to FBX because Blender doesn't understand the armature this tool generates.")
+    # Check if 64-bit version is available
+    if platform == "Windows":
+        pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis64.exe")
+    elif platform == "Darwin":
+        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
+    elif platform == "Linux":
+        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
+    else:
+        print("[FIX 00 - WARNING] UNKNOWN PLATFORM! DEFAULTING TO UNIX...")
+        pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis64.exe")
 
-      if NOESIS != "":
-        print(f"[OVERRIDE] Overriding path for Noesis with {NOESIS}")
-        pathforcheck = NOESIS
     print("[DEBUG] Path for Noesis should be in: " + pathforcheck)
+    SANITYCHECK = path.exists(pathforcheck)
     if SANITYCHECK == True:
-      NoesisStuff(file, pathforcheck)
+        NoesisStuff(file, pathforcheck)
     else:
-      if FIX_COMPLETED == False:
-        print("[FIX - ERROR!] Fix will NOT continue. You don't have Noesis downloaded or didn't put it in the same directory as the converter (Or you misspelled the NOESIS variable if you tried to override the paths!). To download it, go to https://www.richwhitehouse.com/index.php?content=inc_projects.php&showproject=91.")
+        print("[DEBUG] 64-bit version NOT detected.")
+    if FIX_COMPLETED == True:
+        # Check if 32-bit version is available
+        if platform == "Windows":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "\\Noesis.exe")
+        elif platform == "Darwin":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+        elif platform == "Linux":
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+        else:
+            pathforcheck = ((os.path.abspath(os.getcwd())) + "/Noesis.exe")
+
+        # Override if user has a file path for Noesis
+
+            if NOESIS != "":
+                print(f"[OVERRIDE] Overriding path for Noesis with {NOESIS}")
+                pathforcheck = NOESIS
+        print("[DEBUG] Path for Noesis should be in: " + pathforcheck)
+        if SANITYCHECK == True:
+            NoesisStuff(file, pathforcheck)
+        else:
+            if FIX_COMPLETED == False:
+                print("[FIX - ERROR!] Fix will NOT continue. You don't have Noesis downloaded or didn't put it in the same directory as the converter (Or you misspelled the NOESIS variable if you tried to override the paths!). To download it, go to https://www.richwhitehouse.com/index.php?content=inc_projects.php&showproject=91.")
 
 def help():
-  print("""
+    print("""
 Help:
 extract.py [POD path] [GLB path] [-f]
 
@@ -561,30 +561,30 @@ pathout = argv[2]
 check = str(os.path.basename(pathto)).replace(".pod", "_model.xml" )
 print(f"[DEBUG] File to check is {check}")
 for root, dirs, files in os.walk(os.path.dirname(pathto)):
-  for xml in files:
-    if str(xml).endswith(".xml"):
-      print(f"[DEBUG] xml file to check is {xml}")
-    if xml == check:
-      xmlsupport = True
-      print("[XML] XML Detected!")
-      xmlfile = xml
-      xmldata = etree.parse(os.path.join(os.path.dirname(pathto) ,xmlfile))
-      xmlroot = xmldata.getroot()
-      print(f"Model is called {xmlroot.attrib["Name"]}")
+    for xml in files:
+        if str(xml).endswith(".xml"):
+            print(f"[DEBUG] xml file to check is {xml}")
+        if xml == check:
+            xmlsupport = True
+            print("[XML] XML Detected!")
+            xmlfile = xml
+            xmldata = etree.parse(os.path.join(os.path.dirname(pathto) ,xmlfile))
+            xmlroot = xmldata.getroot()
+            print(f"Model is called {xmlroot.attrib["Name"]}")
 
 converter = POD2GLB.open(argv[1])
 #except IndexError:
-#  help()
-#  print("[ERROR!] Please add a path to the POD!")
+#    help()
+#    print("[ERROR!] Please add a path to the POD!")
 try:
-  converter.save(argv[2])
+    converter.save(argv[2])
 except IndexError:
-  help()
-  print("[ERROR!] Add the path/name of the GLB file!")
+    help()
+    print("[ERROR!] Add the path/name of the GLB file!")
 except NameError:
-  print("[ERROR!] GLB not specified.")
+    print("[ERROR!] GLB not specified.")
 try:
-  if argv[3] == "--fix-armature" or "-f":
-    NoesisFix(argv[2])
+    if argv[3] == "--fix-armature" or "-f":
+        NoesisFix(argv[2])
 except IndexError:
-  print("[DEBUG] Will not convert to FBX via Noesis as -f or --fix-armature option was not specified.")
+    print("[DEBUG] Will not convert to FBX via Noesis as -f or --fix-armature option was not specified.")


### PR DESCRIPTION
### Please test:
* Noesis conversion on Windows - does it still work? Does it still find the path just fine?
* ✅ ~~Make sure PVRTexTool still works. Does it still find its path?~~

### Decisions for you to make:
* Should the Python PVR image converter be the default over PVRTexTool?
  - If so, include `texture2ddecoder` in requirements.txt.
  - I guess PVRTexTool can be a fallback option.
  - Hinges on if you find any flaws with its decoding. If you don't, then great.

I had limited testing which is why I'm not confident about it. I don't think there's any question that it is preferred so long as there aren't major flaws.
* There is a new option, `-e`, to embed images in the .glb itself. Should the default for this be true? It is required to load the model in web browsers.
  - But then again three.js throws validation errors and has messed up culling so... maybe for another time.
  - It would also preferably delete the output images when it's done

License note: All of my changes are under the Unlicense/public domain/don't care, have fun.
